### PR TITLE
Make nullify force null values for unknown properties

### DIFF
--- a/src/walk.js
+++ b/src/walk.js
@@ -7,13 +7,20 @@ function walk (object, yanked, schema, nullify) {
     const [originalKey, renamedKey] = key.split('->')
     const newKey = renamedKey || originalKey
 
-    if (!!object && typeof object[originalKey] !== 'undefined') {
+    const isDefined = !!object && typeof object[originalKey] !== 'undefined'
+    
+    if (!!object && (isDefined || nullify)) {
       const { length } = values(value || {})
-
-      if (length) walk(object[originalKey], yanked[newKey] = {}, schema[key], nullify)
-      else yanked[newKey] = object[originalKey]
-    } else if (nullify) {
+            
+      if (length) {
+        // If nullify, then provide an empty object for the nested schema to walk
+        const nextObject = object[originalKey] || {}
+        walk(nextObject, yanked[newKey] = {}, schema[key], nullify)
+      } else if (isDefined) {
+        yanked[newKey] = object[originalKey]
+      } else if (nullify) {
         yanked[newKey] = null
+      }
     }
 
     prune(yanked)

--- a/src/walk.js
+++ b/src/walk.js
@@ -2,7 +2,7 @@ const prune = require('./prune')
 
 const { entries, values } = Object
 
-function walk (object, yanked, schema) {
+function walk (object, yanked, schema, nullify) {
   for (const [key, value] of entries(schema)) {
     const [originalKey, renamedKey] = key.split('->')
     const newKey = renamedKey || originalKey
@@ -10,8 +10,10 @@ function walk (object, yanked, schema) {
     if (!!object && typeof object[originalKey] !== 'undefined') {
       const { length } = values(value || {})
 
-      if (length) walk(object[originalKey], yanked[newKey] = {}, schema[key])
+      if (length) walk(object[originalKey], yanked[newKey] = {}, schema[key], nullify)
       else yanked[newKey] = object[originalKey]
+    } else if (nullify) {
+        yanked[newKey] = null
     }
 
     prune(yanked)

--- a/src/yank.js
+++ b/src/yank.js
@@ -15,8 +15,7 @@ function yank (object, ...args) {
       .replace(/([\w->]+)/g, '"$1"')
       .replace(/((?<!}),|(?<=")\s?}|(?<!})$)/g, ':0$1')
     const parsedSchema = JSON.parse(`{${parsedArgs}}`)
-
-    walk(object, yanked, parsedSchema)
+    walk(object, yanked, parsedSchema, this.nullify)
   }
 
   if (this && this.nullify && isObject(yanked)) {

--- a/tests/yank.spec.js
+++ b/tests/yank.spec.js
@@ -88,7 +88,33 @@ describe('src/yank', () => {
     done()
   })
   
-  it('should return undefined properties when using nullify within renamed properties', done => {
+  it('recreate a full nested schema if the whole object is undefined', () => {
+    const data = {
+      yank: 'one'
+    }
+
+    const schema = [
+      'yank',
+      `notexists: {
+        one,
+        two
+      }`
+    ]
+
+    const nullify = (...args) => yank.call({ nullify: true }, ...args)
+
+    const yanked = nullify(data, schema)
+
+    expect(yanked).toEqual({
+      yank: 'one',
+      notexists: {
+        one: null,
+        two: null,
+      }
+    })  
+  })
+
+  it('should return undefined properties when using nullify within renamed properties', () => {
     const data = {
       yank: 'one',
       nested: {
@@ -111,6 +137,7 @@ describe('src/yank', () => {
     const nullYanked2 = yank(data2, schema)
     const yanked = yank(data, schema)
     
+    // It has renamed the property but with null
     expect(nullYanked).toEqual({
       nested: {
         forced: null,
@@ -118,6 +145,7 @@ describe('src/yank', () => {
       }
     })
     
+    // It does not have the original named property
     expect(nullYanked).not.toEqual({
       nested: {
         notexists: null,
@@ -125,19 +153,26 @@ describe('src/yank', () => {
       }
     })
     
+    // It has left the prop not defined in schema
+    expect(nullYanked).not.toEqual(
+      expect.objectContaining({
+        yank: 'one',
+      })
+      )
+      
+    // The non null version did omit the missing prop
     expect(yanked).toEqual({
       nested: {
         exists: 'two'
       }
     })
     
+    // It is still renaming accordingly if the data was there.
     expect(nullYanked2).toEqual({
       nested: {
         forced: 'three',
         exists: 'two',
       }
     })
-
-    done()
   })
 })

--- a/tests/yank.spec.js
+++ b/tests/yank.spec.js
@@ -48,4 +48,96 @@ describe('src/yank', () => {
       done()
     }
   })
+
+  it('should return undefined properties when using nullify', done => {
+    const data = { exists: 'one', yank: 'two' }
+    const nullify = (...args) => yank.call({ nullify: true }, ...args)
+    const yanked = nullify(data, ['exists', 'notexists'])
+    expect(yanked).toEqual({
+      exists: 'one',
+      notexists: null
+    })
+    done()
+  })
+
+  it('should return undefined properties when using nullify within nested properties', done => {
+    const data = {
+      yank: 'one',
+      nested: {
+        exists: 'two'
+      }
+    }
+    
+    const nullify = (...args) => yank.call({ nullify: true }, ...args)
+    const nullYanked = nullify(data, ['nested: { notexists, exists }'])
+    const yanked = yank(data, ['exists', 'nested: { notexists, exists }'])
+    
+    expect(nullYanked).toEqual({
+      nested: {
+        notexists: null,
+        exists: 'two'
+      }
+    })
+    
+    expect(yanked).toEqual({
+      nested: {
+        exists: 'two'
+      }
+    })
+
+    done()
+  })
+  
+  it('should return undefined properties when using nullify within renamed properties', done => {
+    const data = {
+      yank: 'one',
+      nested: {
+        exists: 'two'
+      }
+    }
+    
+    const data2 = {
+      yank: 'one',
+      nested: {
+        exists: 'two',
+        notexists: 'three'
+      }
+    }
+    
+    const nullify = (...args) => yank.call({ nullify: true }, ...args)
+
+    const schema = ['nested: { notexists->forced, exists }']
+    const nullYanked = nullify(data, schema)
+    const nullYanked2 = yank(data2, schema)
+    const yanked = yank(data, schema)
+    
+    expect(nullYanked).toEqual({
+      nested: {
+        forced: null,
+        exists: 'two'
+      }
+    })
+    
+    expect(nullYanked).not.toEqual({
+      nested: {
+        notexists: null,
+        exists: 'two'
+      }
+    })
+    
+    expect(yanked).toEqual({
+      nested: {
+        exists: 'two'
+      }
+    })
+    
+    expect(nullYanked2).toEqual({
+      nested: {
+        forced: 'three',
+        exists: 'two',
+      }
+    })
+
+    done()
+  })
 })


### PR DESCRIPTION
Hey. I think this is going to be very useful for avoiding unknown errors in the node / rails parity. I don't know if i've done it right. Tests pass though!